### PR TITLE
Use files instead of .npmignore

### DIFF
--- a/database/babel.config.js
+++ b/database/babel.config.js
@@ -1,3 +1,0 @@
-module.exports = {
-  presets: ['@babel/preset-env', '@babel/preset-typescript'],
-};

--- a/database/package-lock.json
+++ b/database/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@spreeloop/database",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@spreeloop/database",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "MIT",
       "devDependencies": {
         "@babel/core": "^7.19.0",

--- a/database/package.json
+++ b/database/package.json
@@ -1,42 +1,44 @@
 {
   "name": "@spreeloop/database",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Spreeloop Core Database package",
   "author": "Spreeloop",
   "test command": "jest",
   "git repository": "https://github.com/spreeloop/core-ts/database",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "/dist"
+  ],
   "scripts": {
     "prepublish": "tsc",
+    "build": "tsc",
     "lint": "eslint --max-warnings=0 --ext .js,.ts .",
     "test": "jest",
     "coverage": "jest --coverage"
   },
   "license": "MIT",
   "keywords": [
-    "database", "firestore", "nodejs"
+    "database",
+    "firestore",
+    "nodejs"
   ],
+  "dependencies": {
+    "firebase-admin": "^11.2.0"
+  },
   "devDependencies": {
-    "@babel/core": "^7.19.0",
     "@babel/preset-env": "^7.19.0",
     "@babel/preset-typescript": "^7.18.6",
     "@types/jest": "^28.1.6",
-    "@types/request": "^2.48.8",
     "@typescript-eslint/eslint-plugin": "^5.30.0",
     "@typescript-eslint/parser": "^5.30.3",
-    "babel-jest": "^29.0.3",
-    "codecov": "^3.8.3",
     "eslint": "^8.19.0",
     "eslint-config-google": "^0.14.0",
     "eslint-config-prettier": "^8.5.0",
     "eslint-plugin-import": "^2.26.0",
     "eslint-plugin-prettier": "^4.0.0",
-    "eslint-plugin-standard": "^5.0.0",
-    "eslint-plugin-vue": "^9.1.1",
-    "firebase-admin": "^11.0.0",
     "jest": "^28.1.3",
     "prettier": "^2.6.0",
-    "ts-node": "^10.9.1",
-    "tslib": "^2.4.0",
     "typescript": "^4.7.4"
   }
 }

--- a/database/src/database.ts
+++ b/database/src/database.ts
@@ -41,7 +41,7 @@ export interface DatabaseDocument<T = unknown> {
 
 /**
  * Class that contains a static enumeration of all
- * final implementation.
+ * final implementations.
  */
 export abstract class Database {
   /**
@@ -76,7 +76,7 @@ export abstract class Database {
   ): Promise<string | undefined>;
 
   /**
-   * Creates or update a database document with the given path.
+   * Creates or updates a database document with the given path.
    * @param {string} path The database path to the document.
    * @param {Partial<Object>} data The database path to the document.
    * @return {boolean} The operation status.

--- a/database/src/utils/path_utils.ts
+++ b/database/src/utils/path_utils.ts
@@ -1,5 +1,5 @@
 /**
- * Returns a the corresponding database path.
+ * Returns the corresponding database path.
  * @param {string} collectionId The ID or name of the collection.
  * @param {string} documentId The ID of the document.
  * @return {string} The full database path of the document.

--- a/database/tsconfig.dev.json
+++ b/database/tsconfig.dev.json
@@ -1,4 +1,4 @@
 {
-  "include": [".eslintrc.js", "index.spec.ts", "jest.config.ts", "jest.before-test.ts", "babel.config.js"],
+  "include": [".eslintrc.js", "index.spec.ts", "jest.config.ts", "jest.before-test.ts"],
   "exclude": []
 }

--- a/database/tsconfig.json
+++ b/database/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "compileOnSave": true,
   "compilerOptions": {
     "declaration": true,
     "esModuleInterop": true,
@@ -10,15 +11,5 @@
     "sourceMap": true,
     "strict": true,
     "target": "es2017"
-  },
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
-  "compileOnSave": true,
-  "include": ["src",
-    "index.ts"
-  ],
-  "exclude": [
-    "node_modules",
-    "dist"
-  ]
+  }
 }


### PR DESCRIPTION
Ensure all generated js source files are included in the package released.